### PR TITLE
Making hash template work with std::string 

### DIFF
--- a/include/flyweight/object.hpp
+++ b/include/flyweight/object.hpp
@@ -162,11 +162,10 @@ template <class U, class E, class A, class T>
 struct hash<flyweight::v1::object<U, E, A, T>> {
   using argument_type = flyweight::v1::object<U, E, A, T>;
   using value_type = typename argument_type::value_type;
-  using hash_type = typename std::remove_const<value_type>::type;
-  using result_type = typename hash<hash_type>::result_type;
+  using result_type = typename hash<U>::result_type;
 
   result_type operator ()(argument_type const& value) const noexcept {
-    return hash<hash_type>{ }(value);
+    return hash<U>{ }(value);
   }
 
 };

--- a/include/flyweight/object.hpp
+++ b/include/flyweight/object.hpp
@@ -161,13 +161,14 @@ namespace std {
 template <class U, class E, class A, class T>
 struct hash<flyweight::v1::object<U, E, A, T>> {
   using argument_type = flyweight::v1::object<U, E, A, T>;
-  using result_type = typename hash<
-    typename argument_type::value_type
-  >::result_type;
+  using value_type = typename argument_type::value_type;
+  using hash_type = typename std::remove_const<value_type>::type;
+  using result_type = typename hash<hash_type>::result_type;
 
   result_type operator ()(argument_type const& value) const noexcept {
-    return hash<typename argument_type::value_type> { }(value);
+    return hash<hash_type>{ }(value);
   }
+
 };
 
 } /* namespace std */

--- a/include/flyweight/object.hpp
+++ b/include/flyweight/object.hpp
@@ -87,13 +87,13 @@ template <class U, class E, class A, class T>
 bool operator == (
   object<U, E, A, T> const& lhs,
   object<U, E, A, T> const& rhs
-) noexcept { return std::equal_to<U> { }(lhs, rhs); }
+) noexcept { return &lhs.get() == &rhs.get(); }
 
 template <class U, class E, class A, class T>
 bool operator != (
   object<U, E, A, T> const& lhs,
   object<U, E, A, T> const& rhs
-) noexcept { return std::not_equal_to<U> { }(lhs, rhs); }
+) noexcept { return &lhs.get() != &rhs.get(); }
 
 template <class U, class E, class A, class T>
 bool operator >= (
@@ -125,7 +125,17 @@ bool operator == (object<U, E, A, T> const& lhs, U const& rhs) {
 }
 
 template <class U, class E, class A, class T>
+bool operator == (U const& lhs, object<U, E, A, T> const& rhs) {
+  return std::equal_to<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
 bool operator != (object<U, E, A, T> const& lhs, U const& rhs) {
+  return std::not_equal_to<U> { }(lhs, rhs);
+}
+
+template <class U, class E, class A, class T>
+bool operator != (U const& lhs, object<U, E, A, T> const& rhs) {
   return std::not_equal_to<U> { }(lhs, rhs);
 }
 

--- a/tests/cache.cpp
+++ b/tests/cache.cpp
@@ -44,6 +44,17 @@ TEST_CASE("cache-size") {
   CHECK(flyweight::cache<std::string>::ref().size() == 2);
 }
 
+TEST_CASE("cache-item-deleter") {
+  CHECK(flyweight::cache<std::string>::ref().size() == 0);
+  {
+    std::string size_1 { "size-1" };
+
+    auto value = flyweight::cache<std::string>::ref().find(size_1);
+    CHECK(flyweight::cache<std::string>::ref().size() == 1);
+  }
+  CHECK(flyweight::cache<std::string>::ref().size() == 0);
+}
+
 /* kv-cache */
 TEST_CASE("kv-cache-is-associative") {
   CHECK(texture_cache::is_associative::value);

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -55,6 +55,8 @@ TEST_CASE("operator-equal") {
 
   CHECK(lhs == text);
   CHECK(rhs == text);
+  CHECK(text == lhs);
+  CHECK(text == rhs);
   CHECK(lhs == rhs);
 }
 
@@ -65,6 +67,8 @@ TEST_CASE("operator-not-equal") {
 
   CHECK(lhs != text);
   CHECK(rhs != text);
+  CHECK(text != lhs);
+  CHECK(text != rhs);
   CHECK(lhs != rhs);
 }
 

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -1,6 +1,7 @@
 #define CATCH_CONFIG_MAIN
 #include <flyweight/object.hpp>
 #include <string>
+#include <unordered_map>
 
 #include <catch.hpp>
 
@@ -105,4 +106,8 @@ TEST_CASE("operator-less") {
   CHECK(lhs < text);
   CHECK(rhs < text);
   CHECK(lhs < rhs);
+}
+
+TEST_CASE("unordered-map-instantiation") {
+  std::unordered_map<flyweight::object<std::string>, int> map;
 }


### PR DESCRIPTION
Hi! This change makes the use of flyweight::objectstd::string as key in an unordered_map possible.Tested with gcc 4.9.  

(Still puzzling through the template docs)
